### PR TITLE
Nueva secuencia de valores creada. Falta testear

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -84,8 +84,16 @@ class OrdersController < ApplicationController
 
         # Actualizar horometro y ver mantenciones
         @grua.horometro = horometro
-        @necesita, @dicc = @grua.evaluar_mantenciones(horometro, @grua.dicc_mantenciones, 
-          @grua.mantenciones, @grua.horometro_inicial)
+        if @grua.tipo == "Gas"
+          elementales = @grua.dicc_mantenciones[350]
+        elsif @grua.tipo == "Apilador"
+          elementales = @grua.dicc_mantenciones[500]
+        else
+          elementales = @grua.dicc_mantenciones[250]
+        end
+        
+        @necesita, @dicc = @grua.evaluar_mantenciones2(horometro, @grua.horometro_inicial, 
+          elementales, @grua.tipo)
         @grua.necesita = @necesita
         if @grua.necesita
           @grua.secuencia = @dicc.keys()[0]

--- a/app/models/grua.rb
+++ b/app/models/grua.rb
@@ -134,6 +134,63 @@ class Grua < ApplicationRecord
  		return false, {}
  	end
 
+ 	def evaluar_mantenciones2(horometro, hor_inicial, mantenciones_elementales, tipo)
+ 		necesita = false
+ 		dicc_a_realizar = {}
+ 		if tipo == "Gas"
+ 			siguiente = 350*(mantenciones_elementales + 1) + hor_inicial
+ 			lista_secuencias = [2100, 1400, 1050, 350]
+ 		elsif tipo == "Apilador"
+ 			siguiente = 500*(mantenciones_elementales + 1) + hor_inicial
+ 			lista_secuencias = [2000, 1000, 500]
+ 		else
+ 			siguiente = 250*(mantenciones_elementales + 1) + hor_inicial
+ 			lista_secuencias = [6000, 2000, 1000, 250]
+ 		end
+
+		faltante = siguiente - horometro
+		if faltante <= 100
+			lista_secuencias.each do |secuencia|
+				if (siguiente - hor_inicial)%secuencia == 0
+					necesita = true
+					dicc_a_realizar[secuencia] = [faltante, siguiente]
+				end
+			end
+		end 		
+ 		return necesita, dicc_a_realizar
+ 	end
+
+ 	def mantenciones_a_mostrar(tipo, hor_inicial, mantenciones_elementales)
+ 		x = mantenciones_elementales
+ 		if tipo == 'Gas'
+	        n = hor_inicial + 350*x
+	        prox_350 = n + 350
+	        prox_1050 = n + 1050 - ((x%3)*350)
+	        prox_1400 = n + 1400 - ((x%4)*350)
+	        prox_2100 = n + 2100 - ((x%6)*350)
+	        mantenciones_a_realizar = {350 => prox_350.to_i, 1050 => prox_1050.to_i, 
+	          1400 => prox_1400.to_i, 2100 => prox_2100.to_i}
+
+	    elsif tipo == "Apilador"
+	    	n = hor_inicial + 500*x
+	    	prox_500 = n + 500
+	    	prox_1000 = n + 1000 - ((x%2)*500)
+	    	prox_2000 = n + 2000 - ((x%4)*500)
+	    	mantenciones_a_realizar = {500 => prox_500.to_i, 1000 => prox_1000.to_i, 
+	    		2000 => prox_2000.to_i}
+
+	    else
+	        n = hor_inicial + 250*x
+	        prox_250 = n + 250
+	        prox_1000 = n + 1000 - ((x%4)*250)
+	        prox_2000 = n + 2000 - ((x%8)*250)
+	        prox_6000 = n + 6000 - ((x%24)*250)
+	        mantenciones_a_realizar = {250 => prox_250.to_i, 1000 => prox_1000.to_i, 
+	          2000 => prox_2000.to_i, 6000 => prox_6000.to_i}
+	    end
+	    return mantenciones_a_realizar
+	end
+
  	def calcular_repuestos(fecha_inicial, fecha_final)
  		ordenes = self.orders.where(:fecha => fecha_inicial..fecha_final).order('fecha ASC')
  		total = 0

--- a/app/views/gruas/show.html.erb
+++ b/app/views/gruas/show.html.erb
@@ -1,5 +1,8 @@
 <center><h1>Grúa Num <%=@grua.numero_serie%></h1></center>
 <center><h2>Horometro: <%= number_with_delimiter(@grua.horometro.to_i, delimiter: ".") %></h2></center>
+
+<%= @grua.dicc_mantenciones %>
+
 <% if @grua.necesita %>
   <div class="jumbotron">
     <center><h2 class="text-danger">Necesita mantención </h2></center>
@@ -10,22 +13,24 @@
         <th>Horas faltantes</th>
         <th>Horas teóricas de mantención</th>
       </thead>
-      <tbody>
 
-        <tr>
-          <td>Cada <%= @grua.secuencia %> horas</td>
-          <% if @grua.horas_faltantes <= 0 %>
-            <td class="text-danger"><%= number_with_delimiter(@grua.horas_faltantes.to_i, delimiter: ".") %> horas</td>
-          <% else %>
-            <td><%= number_with_delimiter(@grua.horas_faltantes.to_i, delimiter: ".") %> horas</td>
-          <% end %>
-          <td><%= number_with_delimiter(@grua.horas_teoricas.to_i, delimiter: ".")%> horas</td>
-          <td><%= link_to "Realizada", mantencion_realizada_path(grua_id: @grua.id, secuencia: @grua.secuencia) %></td>
-        </tr>
-        
+      <tbody>
+        <% @dicc.each do |key, value| %>
+          <tr>
+            <td>Cada <%= key %> horas</td>
+            <% if value[0] <= 0 %>
+              <td class="text-danger"><%= value[0] %> horas</td>
+            <% else %>
+              <td><%= value[0] %> horas</td>
+            <% end %>
+            <td><%= number_with_delimiter(value[1].to_i, delimiter: ".") %> horas</td>
+            <td><%= link_to "Realizada", mantencion_realizada_path(grua_id: @grua.id, secuencia: @grua.secuencia) %></td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   </div>
+  
 <% else %>
   <div class="jumbotron">
     <center><h2 class="text-success">Mantenciones al día</h2></center>
@@ -36,12 +41,12 @@
         <th>Próxima mantención</th>
       </thead>
       <tbody>
-        <% @grua.dicc_mantenciones.each do |secuencia, veces| %>
+        <% @mantenciones_a_realizar.each do |secuencia, prox| %>
           <tr>
-            <td>Cada <%= secuencia %> horas</td>
-            <td><%= number_with_delimiter((secuencia.to_f*(veces.to_f + 1)).to_i + @grua.horometro_inicial.to_i, delimiter: ".") %></td>
+            <td>Cada <%=secuencia%> horas</td>
+            <td><%= number_with_delimiter(prox, delimiter: ".") %></td>
           </tr>
-        <% end %>
+        <%end%>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
Nueva secuencia de mantenciones para grúas a gas.
Se cambia todo el funcionamiento del programa, ahora es en base solo a la mantencion mas básica o elemental: 250 hrs, 350 hrs o 500 hrs para eléctricas, gas y apiladores respectivamente.